### PR TITLE
Country displays normally when first proposal

### DIFF
--- a/app/controllers/choogles_controller.rb
+++ b/app/controllers/choogles_controller.rb
@@ -15,7 +15,7 @@ class ChooglesController < ApplicationController
     @hash = Gmaps4rails.build_markers(proposals) do |proposal, marker|
       marker.lat proposal.place.latitude
       marker.lng proposal.place.longitude
-      marker.json({ :id => proposal.id })
+      marker.json({ :id => proposal.id, :address => proposal.place.address, :country => proposal.place.country })
       marker.infowindow render_to_string(partial: "/proposals/map_box", locals: { proposal: proposal })
     end
     @user = current_or_guest_user

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -3,6 +3,12 @@ class Place < ApplicationRecord
   has_many :choogles, through: :proposals
   geocoded_by :address
   after_validation :geocode, if: :address_changed?
+  reverse_geocoded_by :latitude, :longitude do |obj, results|
+    if geo = results.first
+      obj.country = geo.country
+    end
+  end
+  after_validation :fetch_address
 
   def placify
     @client = GooglePlaces::Client.new(ENV['GOOGLE_API_SERVER_KEY'])

--- a/app/views/shared/_map.html.erb
+++ b/app/views/shared/_map.html.erb
@@ -14,6 +14,8 @@
         handler.fitMapToBounds();
         if (markers.length == 0) {
           handler.getMap().setZoom(14);
+        } else if (markers.length == 1 && markers[0].country == markers[0].address) {
+          handler.getMap().setZoom(5);
         } else if (markers.length == 1) {
           handler.getMap().setZoom(15);
         }

--- a/db/migrate/20170907081649_add_country_to_places.rb
+++ b/db/migrate/20170907081649_add_country_to_places.rb
@@ -1,0 +1,5 @@
+class AddCountryToPlaces < ActiveRecord::Migration[5.0]
+  def change
+    add_column :places, :country, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170830093547) do
+ActiveRecord::Schema.define(version: 20170907081649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,10 +19,10 @@ ActiveRecord::Schema.define(version: 20170830093547) do
     t.string   "title"
     t.datetime "due_at"
     t.datetime "happens_at"
-    t.integer  "user_id"
     t.string   "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "user_id"
     t.index ["user_id"], name: "index_choogles_on_user_id", using: :btree
   end
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20170830093547) do
     t.float    "longitude"
     t.string   "api_google_id"
     t.float    "rating"
+    t.string   "country"
   end
 
   create_table "proposal_tags", force: :cascade do |t|


### PR DESCRIPTION
**Issue:** when voting for a country as a first proposal, it was very zoomed in on the map.

**Proposed solution:**
- we add a Country column to Place model
- when displaying markers, we check if place.address == place.country (ie, we're testing if this place is a country)
- if so, zoom at 5

**This fix will only work for Places generated with this new migration.**
**Don't forget to db:migrate**

Next step: adding country info to Places object already in production DB.