### PR TITLE
Loader when submit proposal

### DIFF
--- a/app/assets/stylesheets/components/_proposal.scss
+++ b/app/assets/stylesheets/components/_proposal.scss
@@ -239,3 +239,20 @@
 //     color: $purple;
 //   }
 // }
+
+.loader {
+  margin: auto;
+  display: none;
+  justify-content: space-around;
+  border: 2px solid white;
+  border-top: 2px solid $orange;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for([choogle, proposal], remote: true) do |f| %>
+<%= simple_form_for([choogle, proposal], remote: true, html: { class: "form-proposal"}) do |f| %>
   <div id="proposal-errors"></div>
 
   <!-- If it's a guest session, ask for his name -->
@@ -11,6 +11,8 @@
   <%= f.association :tags, class: 'tag-selector', collection: current_or_guest_user.tags, label: "Add tags to this place (max 20 char)" %>
   <%= f.button :submit, value: "Add a new place", class: 'btn btn-choogle btn-proposal-margin' %>
 <% end %>
+<div class="loader"></div>
+
 
 <script>
   $("#proposal_tag_ids").select2(
@@ -47,5 +49,11 @@
         writeStyles('styles_js', cssText);
       }
     });
+  });
+
+  $(".form-proposal").submit(function() {
+      $(".loader").show();
+      $(this).find(".btn").hide();
+      return true;
   });
 </script>

--- a/app/views/proposals/errors.js.erb
+++ b/app/views/proposals/errors.js.erb
@@ -1,2 +1,4 @@
 $("#proposal-errors").empty()
 $("#proposal-errors").append("<%= @proposal.errors.full_messages.join %>")
+$(".loader").hide()
+$(".form-proposal").find(".btn").show()


### PR DESCRIPTION
**Issue:** Creating a proposal takes some time (1-3 sec), during which the user has no feedback about his submission (is it okay ? should I click the button again?).

**Solution:**
A simple loader animated in CSS, which temporarily replaces the submit button. In case of validation errors, the button reappears and the loader is hidden.

I know it wasn't in the Trello, but it had been discussed before and was a quick fix. What do you guys think?