### PR TITLE
email display in the footer

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,8 @@
 <div class="footer">
   <div class="footer-links">
-    <a href="https://github.com/clement-bergantz/CHOOGLE" target="blank"><i class="fa fa-github"></i></a>
-    <a href="https://twitter.com/choogle_xyz" target="blank"><i class="fa fa-twitter"></i></a>
+<!--     <a href="https://github.com/clement-bergantz/CHOOGLE" target="blank"><i class="fa fa-github"></i></a>
+    <a href="https://twitter.com/choogle_xyz" target="blank"><i class="fa fa-twitter"></i></a> -->
+    <a href="mailto:hello@choogle.xyz" target="blank"><i class="fa fa-envelope"></i></a>
+    <p style="margin: 0px">hello@choogle.xyz</p>
   </div>
 </div>


### PR DESCRIPTION
- Twitter : we have an account, but nothing to say now
- Github : users don't care about our GitHub, they even don't know what's an open source program
- Mail : now everyone can contact us, our email is displayed and the envelope icon is a mail:to
