### PR TITLE
fix bootsrap problems on home

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -46,10 +46,10 @@
       <div id="slider" class="carousel slide col-xs-8  padd-lt0" data-ride="carousel" data-interval="10000" data-pause="hover">
         <div class="carousel-inner">
           <div class="item active">
-              <img alt="First slide"4 src="assets/festival.jpg" >   
+              <img alt="First slide"4 src="assets/festival.jpg" >
           </div>
           <div class="item">
-              <img alt="Second slide" src="assets/afterwork.jpg">  
+              <img alt="Second slide" src="assets/afterwork.jpg">
           </div>
           <div class="item">
               <img alt="Third slide" src="assets/weekend.jpg">
@@ -99,8 +99,8 @@
 <script src="https://maps.googleapis.com/maps/api/js?libraries=places&amp;key=<%= ENV['GOOGLE_API_BROWSER_KEY']%>"></script>
 
 <!-- Loading for the Bootstrap carousel -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.js"></script>
-<script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script> -->
 
 <% content_for(:after_js) do %>
   <script>


### PR DESCRIPTION
Clement, i commented thoses 2 lines scripts cdn because it was in conflict with already installed gems for jquery and bootstrap. the carousel seems to work well without thoses and the dropdown navbar is working again on home. If you need theses we can discuss to find a better way for not overriding the bootstrap gems on home. If its ok for you, you can merge this.