### PR TITLE
Validation on name for proposal

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -26,7 +26,7 @@ class Proposal < ApplicationRecord
 
   def name_cannot_be_empty
     if self.user.first_name.empty?
-      errors.add(:first_name, "Please enter a name!")
+      errors.add(:first_name, "Please enter a name")
     end
   end
 end


### PR DESCRIPTION
Guest has to enter a name to submit a proposal.

Caveat: error message is doubled with another one I cannot retrieve in the code. Not very U-friendly but does the job for now.