### PR TITLE
Delete old guests

### DIFF
--- a/app/models/choogle.rb
+++ b/app/models/choogle.rb
@@ -1,8 +1,8 @@
 class Choogle < ApplicationRecord
   belongs_to :user
-  has_many :comments
-  has_many :proposals
-  has_many :notifications
+  has_many :comments, dependent: :destroy
+  has_many :proposals, dependent: :destroy
+  has_many :notifications, dependent: :destroy
   has_many :places, through: :proposals
 
   validates :slug, presence: true

--- a/app/models/upvote.rb
+++ b/app/models/upvote.rb
@@ -8,12 +8,14 @@ class Upvote < ApplicationRecord
 
   def broadcast_upvotes
     # looking for all clients on the broadcast and push upvotes size and proposal id
-    ActionCable.server.broadcast(
-    "upvote_#{proposal.choogle.slug}",
-    upvotes: self.proposal.upvotes.size,
-    proposal_id: self.proposal.id,
-    user_id: self.user.id,
-    upvoters: self.proposal.upvoters,
-    )
+    if proposal
+      ActionCable.server.broadcast(
+      "upvote_#{proposal.choogle.slug}",
+      upvotes: self.proposal.upvotes.size,
+      proposal_id: self.proposal.id,
+      user_id: self.user.id,
+      upvoters: self.proposal.upvoters,
+      )
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :omniauthable, omniauth_providers: [:facebook]
-  has_many :notifications
-  has_many :choogles
-  has_many :upvotes
-  has_many :proposals
-  has_many :comments
+  has_many :notifications, dependent: :destroy
+  has_many :choogles, dependent: :destroy
+  has_many :upvotes, dependent: :destroy
+  has_many :proposals, dependent: :destroy
+  has_many :comments, dependent: :destroy
   # With this and has_many tags on proposal we can call user.tags
   # to get all the tags used by a user on his proposals.
   has_many :tags, through: :proposals

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,7 @@
+namespace :users do
+  desc "TODO"
+  task delete_30_days_old_guests: :environment do
+    User.where(['created_at < ? AND email LIKE ?', 30.days.ago, '%@example.com']).count
+  end
+
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,7 +1,9 @@
 namespace :users do
-  desc "TODO"
+  desc "Deleting guests older than 30 days"
   task delete_30_days_old_guests: :environment do
-    User.where(['created_at < ? AND email LIKE ?', 30.days.ago, '%@example.com']).count
+    User.where(['created_at < ? AND email LIKE ?', 30.days.ago, '%@example.com']).each do |user|
+      user.destroy
+    end
   end
 
 end


### PR DESCRIPTION
- Add a new task `rake users:delete_30_days_old_guests`
- Add `dependent: :destroy` relationships to effectively delete users and their choogles, proposals, upvotes, comments, etc.